### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: Android CI
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/leona180913/tuty_dias/security/code-scanning/1](https://github.com/leona180913/tuty_dias/security/code-scanning/1)

To fix the problem, we need to add a `permissions` block to the workflow. The location can be either at the root (before `jobs:`) to set permissions for all jobs, or within the individual job (`build:` in this case). Since there is only one job and its steps do not require write access to the repository, we should set the minimal necessary permissions—generally `contents: read` suffices for code checkout operations. Edit `.github/workflows/android.yml` and insert `permissions:` with `contents: read` directly beneath the workflow name and before the `on:` block (lines 2–3).

No new methods or imports are needed. The change is a minimal addition of a YAML block.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
