### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -6,6 +6,8 @@ on:
   pull_request:
     branches: [ "main" ]
 
+permissions:
+  contents: read
 jobs:
   build:
 


### PR DESCRIPTION
Potential fix for [https://github.com/leona180913/tuty_dias/security/code-scanning/1](https://github.com/leona180913/tuty_dias/security/code-scanning/1)

To fix the problem, we need to add a `permissions` block that restricts the GITHUB_TOKEN to read-only access for repository contents (code). The safest and simplest way is to set:

```yaml
permissions:
  contents: read
```

at either the root of the workflow (for all jobs unless otherwise specified), or specifically under the `build` job if you only want to restrict permissions there. Since the workflow contains just one job (`build`), placing it at the workflow root is efficient and future-proof. No changes to the steps or logic are required, and no new dependencies or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
